### PR TITLE
OHRI-1749: Error in saving the Service Enrolment Form

### DIFF
--- a/distro/configuration/ampathforms/ct_service_enrolment_v1.0.json
+++ b/distro/configuration/ampathforms/ct_service_enrolment_v1.0.json
@@ -976,7 +976,7 @@
               "label": "Test Location",
               "type": "obs",
               "questionOptions": {
-                "rendering": "text",
+                "rendering": "select",
                 "concept": "161549AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "answers": [
                   {


### PR DESCRIPTION
Error in saving the Service Enrolment Form

The concept `Test location` is a `coded` concept. However, it was rendering `text`.

![image](https://github.com/UCSF-IGHS/openmrs-distro-referenceapplication/assets/130601439/b3ce7aec-888f-426b-8052-35bbca7d05a1)


