### PR TITLE
OHRI-1670: Fix the duplication of the dispensing widget on dev

### DIFF
--- a/frontend/ohri-config.json
+++ b/frontend/ohri-config.json
@@ -43,11 +43,6 @@
         "add": [
           "clinical-appointments-dashboard"
         ]
-      },
-      "ohri-dashboard-dispensing-slot": {
-        "add": [
-          "dispensing-dashboard"
-        ]
       }
     }
   },


### PR DESCRIPTION
- The duplication only happens on the dev environment. 

- Reason of duplication -  we have the **dispensing-dashboard**  in both  the esm-core-app  and  in the distro/frontend /ohri-config.
- We have changed this config file so that the dispensing can also display locally
- ![image](https://github.com/UCSF-IGHS/openmrs-distro-referenceapplication/assets/130601439/9a2a4567-f779-4723-bcb3-931bb67f0767)

![image](https://github.com/UCSF-IGHS/openmrs-distro-referenceapplication/assets/130601439/def1a38f-e59c-48e6-8208-46bb4bcb2dec)
